### PR TITLE
Don't fetch contact if client isn't signed in

### DIFF
--- a/src/app/profile/[userId]/_components/Profile/Contacts/Contacts.tsx
+++ b/src/app/profile/[userId]/_components/Profile/Contacts/Contacts.tsx
@@ -23,6 +23,7 @@ export default function Contacts({
     error: contactError,
   } = trpc.contact.getContact.useQuery(
     { userId },
+    // Doesn't fetch if not signed in
     {
       enabled: !!isSignedIn,
     }
@@ -110,7 +111,7 @@ export default function Contacts({
         </div>
       )}
       <div className="mt-auto flex items-end justify-end p-4">
-        {profile?.userId === userId && (
+        {isSignedIn && profile?.userId === userId && (
           <Button
             className="w-full border border-gray-400 bg-profile_button_bg text-xs text-black hover:bg-primary_blue hover:text-white focus:bg-primary_blue focus:text-white sm:w-20"
             aria-label="Edit your Profile"
@@ -129,7 +130,6 @@ export default function Contacts({
             Contact
           </Button>
         </SignedOut>
-        {/* )} */}
       </div>
     </div>
   );

--- a/src/app/profile/[userId]/_components/Profile/Contacts/Contacts.tsx
+++ b/src/app/profile/[userId]/_components/Profile/Contacts/Contacts.tsx
@@ -1,17 +1,18 @@
 import { useUser } from '@clerk/nextjs';
+import { SignedOut } from '@clerk/nextjs';
 import { trpc } from '@/lib/trpc/client';
 import { Button } from '@/components/ui/button';
 import IconComponents from '../IconComponents';
 
 interface ContactsProps {
   userId: string;
-  // toggleSignInPopUp: React.Dispatch<React.SetStateAction<boolean>>;
+  toggleSignInPopUp: React.Dispatch<React.SetStateAction<boolean>>;
   toggleEditing: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function Contacts({
   userId,
-  // toggleSignInPopUp,
+  toggleSignInPopUp,
   toggleEditing,
 }: ContactsProps) {
   const { isSignedIn } = useUser();
@@ -20,8 +21,12 @@ export default function Contacts({
     data: contact,
     isLoading: isContactLoading,
     error: contactError,
-    // refetch: refetchContact,
-  } = trpc.contact.getContact.useQuery({ userId });
+  } = trpc.contact.getContact.useQuery(
+    { userId },
+    {
+      enabled: !!isSignedIn,
+    }
+  );
 
   if (isContactLoading) return <div className="">Contact Loading</div>;
   if (contactError) return <div className="">{contactError.message}</div>;
@@ -115,17 +120,16 @@ export default function Contacts({
           </Button>
         )}
         {/* TODO: Add the SignedOut at the HOME PAGE level*/}
-        {/* {!profile?.isContactPublic && (
-          <SignedOut>
-            <Button
-              onClick={() => toggleSignInPopUp(true)}
-              className="w-full border border-gray-400 bg-profile_button_bg text-xs text-black hover:bg-primary_blue hover:text-white focus:bg-primary_blue focus:text-white sm:w-20"
-              aria-label={`Contact`}
-            >
-              Contacts
-            </Button>
-          </SignedOut>
-        )} */}
+        <SignedOut>
+          <Button
+            onClick={() => toggleSignInPopUp(true)}
+            className="w-full border border-gray-400 bg-profile_button_bg text-xs text-black hover:bg-primary_blue hover:text-white focus:bg-primary_blue focus:text-white sm:w-20"
+            aria-label={`Contact`}
+          >
+            Contact
+          </Button>
+        </SignedOut>
+        {/* )} */}
       </div>
     </div>
   );

--- a/src/app/profile/[userId]/_components/Profile/Edit/EditBio/EditBio.tsx
+++ b/src/app/profile/[userId]/_components/Profile/Edit/EditBio/EditBio.tsx
@@ -17,7 +17,8 @@ export default function EditBio({ userId, setIsEditing }: EditBioProps) {
   const { toast } = useToast();
   // const utils = trpc.useUtils();
 
-  const { data: profile } = trpc.profile.getFullProfile.useQuery({ userId });
+  const { data: profile, refetch: refetchProfile } =
+    trpc.profile.getFullProfile.useQuery({ userId });
 
   const form = useForm<ProfileEditForm>({
     resolver: zodResolver(profileEditSchema),
@@ -39,6 +40,7 @@ export default function EditBio({ userId, setIsEditing }: EditBioProps) {
         title: 'Profile Updated!',
         description: 'Your profile has been updated successfully',
       });
+      refetchProfile();
     },
     onError: () => {
       toast({

--- a/src/app/profile/[userId]/_components/Profile/Edit/EditContacts/EditContacts.tsx
+++ b/src/app/profile/[userId]/_components/Profile/Edit/EditContacts/EditContacts.tsx
@@ -20,7 +20,8 @@ export default function EditContacts({
   setIsEditing,
   userId,
 }: EditContactsProps) {
-  const { data: contact } = trpc.contact.getContact.useQuery({ userId });
+  const { data: contact, refetch: refetchContact } =
+    trpc.contact.getContact.useQuery({ userId });
   const { toast } = useToast();
 
   const form = useForm<ContactEditForm>({
@@ -43,6 +44,7 @@ export default function EditContacts({
         title: 'Contact Updated!',
         description: 'Your contact has been updated successfully',
       });
+      refetchContact();
     },
     onError: () => {
       toast({

--- a/src/app/profile/[userId]/_components/Profile/Profile.tsx
+++ b/src/app/profile/[userId]/_components/Profile/Profile.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useState } from 'react';
 import EditProfile from '@/app/profile/[userId]/_components/Profile/Edit/EditProfile';
-// import SignInPopUp from '@/components/Popups/SignIn/SignInPopUp';
+import SignInPopUp from '@/components/Popups/SignIn/SignInPopUp';
 import { trpc } from '@/lib/trpc/client';
 import { usePathname } from 'next/navigation';
 import Bio from './Bio/Bio';
@@ -24,7 +24,7 @@ export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
   const pathname = usePathname();
   const userId = pathname.split('/').pop() || '';
-  // const [showSignInPopUp, setShowSignInPopUp] = useState(false);
+  const [showSignInPopUp, setShowSignInPopUp] = useState(false);
 
   const {
     data: profile,
@@ -43,9 +43,9 @@ export default function Profile() {
   const toggleEditing = () => {
     setIsEditing(!isEditing);
   };
-  // const toggleSignInPopUp = () => {
-  //   setShowSignInPopUp(!showSignInPopUp);
-  // };
+  const toggleSignInPopUp = () => {
+    setShowSignInPopUp(!showSignInPopUp);
+  };
 
   const usersFullName = `${profile?.firstName} ${profile?.lastName}`;
 
@@ -82,7 +82,7 @@ export default function Profile() {
               <div className="w-full md:w-auto">
                 <Contacts
                   userId={userId}
-                  // toggleSignInPopUp={toggleSignInPopUp}
+                  toggleSignInPopUp={toggleSignInPopUp}
                   toggleEditing={toggleEditing}
                 />
               </div>
@@ -96,7 +96,7 @@ export default function Profile() {
         </>
       )}
 
-      {/* {showSignInPopUp && <SignInPopUp onToggle={toggleSignInPopUp} />} */}
+      {showSignInPopUp && <SignInPopUp onToggle={toggleSignInPopUp} />}
     </div>
   );
 }

--- a/src/server/routers/PhotoAlbum/mutations.ts
+++ b/src/server/routers/PhotoAlbum/mutations.ts
@@ -4,7 +4,6 @@ import prisma from '@prisma/prisma';
 import { createPhotoAlbum as create } from './utils';
 import { deletePhotoCommand } from '../Images/s3-delete';
 
-// TODO: Add limit to the amount of characters in the photo album name (Both create and update for backend and frontend)
 export const createPhotoAlbum = protectedProcedure
   .input(
     z.object({


### PR DESCRIPTION
- Make sure our trpc doesn't do unnecessary fetches when the user isn't logged in or for data that a user isn't supposed to see.
- Re-added SignIn popup at the Profile Page Level.
- Let's try to move it to the Home Page level.
- ReFetches profile data once they are updated.